### PR TITLE
handle dictionary type parameters

### DIFF
--- a/plugins/module_utils/ibmcloud.py
+++ b/plugins/module_utils/ibmcloud.py
@@ -1078,7 +1078,7 @@ def fmt_tf_block(
         if len(validate_tl_params) > 0 and key not in validate_tl_params:
             continue
         if isinstance(value, dict):
-            output += indent() + key + ' {\n'
+            output += indent() + key + ' = {\n'
             output += fmt_tf_block(value, indent_count + 1, indent_spaces)
             output += indent(-1) + '}\n'
         elif isinstance(value, list):


### PR DESCRIPTION
This PR is related to https://github.com/IBM-Cloud/ansible-collection-ibm/issues/8 .

This patch is based on the terraform doc statement,
```
Terraform 0.12 now enforces using argument syntax (with an equals sign) for normal attributes and primitive-typed collections, and block syntax (with no equals sign) for collections with an element type of *schema.Resource.
```