### PR TITLE
expose the Terraform optional parameter resource_group_id

### DIFF
--- a/docs/ibm_resource_instance_info.rst
+++ b/docs/ibm_resource_instance_info.rst
@@ -42,11 +42,12 @@ Parameters
     The IBM Cloud region where you want to create your resources. If this value is not specified, us-south is used by default. This can also be provided via the environment variable 'IC_REGION'.
 
 
+  resource_group_id (False, str, None)
+    The resource group id
+
+
   ibmcloud_api_key (True, any, None)
     The IBM Cloud API key to authenticate with the IBM Cloud platform. This can also be provided via the environment variable 'IC_API_KEY'.
-
-
-
 
 
 
@@ -61,4 +62,3 @@ Authors
 ~~~~~~~
 
 - Jay Carman (@jaywcarman)
-

--- a/plugins/modules/ibm_resource_instance_info.py
+++ b/plugins/modules/ibm_resource_instance_info.py
@@ -44,6 +44,11 @@ options:
               environment variable 'IC_REGION'.
         default: us-south
         required: False
+    resource_group_id:
+        description:
+            - The resource group id
+        required: False
+        type: str
     ibmcloud_api_key:
         description:
             - The IBM Cloud API key to authenticate with the IBM Cloud
@@ -63,9 +68,10 @@ TL_REQUIRED_PARAMETERS = [
 # All top level parameter keys supported by Terraform module
 TL_ALL_PARAMETERS = [
     'name',
+    'resource_group_id',
 ]
 
-# Params for Data source 
+# Params for Data source
 TL_REQUIRED_PARAMETERS_DS = [
 ]
 
@@ -96,6 +102,9 @@ module_args = dict(
         type='str',
         fallback=(env_fallback, ['IC_REGION']),
         default='us-south'),
+    resource_group_id=dict(
+        required= False,
+        type='str'),
     ibmcloud_api_key=dict(
         type='str',
         no_log=True,


### PR DESCRIPTION
The resource_group_id is available on the ibm_resource_instance module but is not on the ibm_resource_instance_info module. When attempting to query an IBM Cloud resource if not in the default resource group the query will fail.