### PR TITLE
[WIP] Add 'ibm vpc instance' role

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,4 @@
+.facts/
+ansible.cfg
+hosts
+venv/

--- a/examples/sap-hana-vm/create.yml
+++ b/examples/sap-hana-vm/create.yml
@@ -1,0 +1,37 @@
+---
+- hosts: localhost
+  collections:
+    - ibm.cloudcollection
+  roles:
+    - role: ibm_vpc_instance
+      vars:
+        ibm_vpc_instance_name: hana-vm1
+        ibm_vpc_instance_profile: cx2-2x4
+        ibm_vpc_instance_image: ibm-redhat-7-6-amd64-sap-hana-1
+        ibm_vpc_instance_vpc: customer-vpc1
+        ibm_vpc_instance_zone: us-south-1
+        ibm_vpc_instance_subnets:
+          - name: subnet1-mzr1
+            ipv4_cidr_block: 172.30.255.128/28
+        ibm_vpc_instance_primary_network_interface:
+          - subnet: subnet1-mzr1
+            name: eth0
+            #security_groups:
+            #  - sg_1_name
+            #  - sg_2_name
+        ibm_vpc_instance_keys:
+          - name: jump
+            public_key: "ssh-rsa <YOUR PUBLIC KEY>"
+        ibm_vpc_instance_volumes:
+          - name: hana-d1
+            capacity: 500
+            iops: 10000
+            profile: custom
+          - name: hana-d2
+            capacity: 500
+            iops: 10000
+            profile: custom
+          - name: hana-d3
+            capacity: 500
+            iops: 10000
+            profile: custom

--- a/examples/sap-hana-vm/example.yml
+++ b/examples/sap-hana-vm/example.yml
@@ -1,0 +1,46 @@
+- hosts: localhost
+  collections:
+    - ibm.cloudcollection
+  roles:
+    - role: ibm_vpc_instance
+      vars:
+        ibm_vpc_instance_name: instance1
+        ibm_vpc_instance_profile: cx2-2x4
+        ibm_vpc_instance_image: ibm-redhat-7-6-amd64-sap-hana-1
+        ibm_vpc_instance_vpc: ansible-test
+        ibm_vpc_instance_primary_network_interface:
+          name: ansible-test-subnet
+          ipv4_cidr_block: 10.240.0.0/24
+          zone: us-south-1
+        ibm_vpc_instance_keys:
+          - name: testkey
+            public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDm+dD4O+oqKCNyh\
+                         pV0Qj5QRCerPBsCysunyw8WP14X/AwqG8iyg5z9C5k/gOc1zCN+FW\
+                         anQO2T+A6JfW8PZU02qhYC3mEzjiYhyAyFvfx74FGcBLdtbI9Qchj\
+                         wNLt2sZGy387mkW50+uroTLujZtGoF6xfX4mwxqYeDNC74YSF+gzc\
+                         qJGWwb7rTdKKSgWfXQFLiegC4GLFOuKNZ1DluUsQD/+dfrQ3SUzp4\
+                         84x/efDPf33hWEsqCbS210U1h/iUa7PQ489v4VC147oSxyiiWAHbE\
+                         ryZ8pW9JDDiPxaLM5LqSJFuJguPlTUsap8oL/zPiDDL7guCzswKzL\
+                         UOOxWtSBwv7XoGdKlYXNXSDZtaGIGKTpU+cHjz18q4xfuoR57j+rs\
+                         qQOIhyzDDt6KusKihMapRVceqJyz+HNunwN0mLJiFFvAtzOHoOneM\
+                         7bYZAXXzY9YgAI+x6CHFhg0VsyXWEtpL0b2iGL/XA3dXh8zV3Kw0H\
+                         RuUPjb02rhWJjuQLY3cpU= \
+                         jwcarman@li-a36b264c-2e6f-11b2-a85c-fdfb37238350.ibm.com"
+          - name: existing_key
+        ibm_vpc_instance_floating_ip:
+          name: instance1-fip
+        ibm_vpc_instance_security_group_rules:
+          - state: available
+            direction: inbound
+            remote: 0.0.0.0/0
+            tcp:
+              - port_max: 22
+                port_min: 22
+        ibm_vpc_instance_volumes:
+          - name: testvol0
+            capacity: 50
+            iops: 100
+            profile: custom
+            zone: us-south-1
+          - name: existingvolume1
+          - name: existingvolume2

--- a/roles/ibm_vpc_instance/.travis.yml
+++ b/roles/ibm_vpc_instance/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/roles/ibm_vpc_instance/README.md
+++ b/roles/ibm_vpc_instance/README.md
@@ -1,0 +1,38 @@
+Ansible Role: ibm_vpc_instance
+==============================
+
+Provision and configure virtual server instances in [IBM Cloud VPC](https://www.ibm.com/cloud/vpc).
+
+Requirements
+------------
+
+This role uses modules included in the [IBM Cloud Ansible Collection](https://galaxy.ansible.com/ibm/cloudcollection).
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+MPL-2.0
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/ibm_vpc_instance/defaults/main.yml
+++ b/roles/ibm_vpc_instance/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for ibm_vpc_instance

--- a/roles/ibm_vpc_instance/handlers/main.yml
+++ b/roles/ibm_vpc_instance/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for ibm_vpc_instance

--- a/roles/ibm_vpc_instance/meta/main.yml
+++ b/roles/ibm_vpc_instance/meta/main.yml
@@ -1,0 +1,12 @@
+galaxy_info:
+  author: jaywcarman
+  description: IBM Cloud VPC Virtual Server Instance
+  company: IBM
+  license:
+    - "MPL-2.0"
+  min_ansible_version: 2.9
+  galaxy_tags:
+    - ibm
+    - ibmcloud
+    - cloud
+dependencies: []

--- a/roles/ibm_vpc_instance/tasks/main.yml
+++ b/roles/ibm_vpc_instance/tasks/main.yml
@@ -310,8 +310,6 @@
     - ibm_vpc_instance_floating_ip.name is defined
     - ibm_vpc_instance_floating_ip.name != None
 
-# TODO: Lookup Floating IP target by interface name
-# "{{ instance_config.resource.network_interfaces + instance_config.resource.primary_network_interface }}
 - name: Configure floating IP address
   ibm.cloudcollection.ibm_is_floating_ip:
     state: "{{ ibm_vpc_instance_floating_ip.state | default('available') }}"

--- a/roles/ibm_vpc_instance/tasks/main.yml
+++ b/roles/ibm_vpc_instance/tasks/main.yml
@@ -102,11 +102,10 @@
 - name: Translate primary network interface security group name to ID
   set_fact:
     primary_network_interface_sgs: "{{ (primary_network_interface_sgs | default([])) + [name_to_id] }}"
-  loop: "{{ primary_network_interface.security_groups }}"
+  loop: "{{ primary_network_interface[0].security_groups }}"
   vars:
     name_to_id: "{{ security_group_map[item] | default(item) }}"
-  when:
-    - primary_network_interface.security_groups is defined
+  when: primary_network_interface[0].security_groups is defined
 
 - name: Build primary network interface with security group IDs
   set_fact:

--- a/roles/ibm_vpc_instance/tasks/main.yml
+++ b/roles/ibm_vpc_instance/tasks/main.yml
@@ -162,7 +162,7 @@
 
 - name: Build network interfaces list with security group IDs
   set_fact:
-    network_interfaces_with_ids: "{{ (network_interfaces_with_ids | default([])) + [item | combine({'security_groups': (network_interfaces_sgs[interface_index] | default(vpc_config.resource.default_security_group))})] }}"
+    network_interfaces_with_ids: "{{ (network_interfaces_with_ids | default([])) + [item | combine({'security_groups': [(network_interfaces_sgs[interface_index] | default(vpc_config.resource.default_security_group))]})] }}"
   loop: "{{ network_interfaces }}"
   loop_control:
     index_var: interface_index

--- a/roles/ibm_vpc_instance/tasks/main.yml
+++ b/roles/ibm_vpc_instance/tasks/main.yml
@@ -40,6 +40,52 @@
     name: "{{ ibm_vpc_instance_vpc | default(omit) }}"
   register: vpc_config
 
+- name: Check for existing security groups
+  ibm.cloudcollection.ibm_is_security_group_info:
+    name: "{{ item.name }}"
+  loop: "{{ ibm_vpc_instance_security_groups }}"
+  failed_when:
+    - security_group_existing.rc != 0
+  register: security_group_existing
+  when: ibm_vpc_instance_security_groups is defined
+
+- name: Configure security groups
+  ibm.cloudcollection.ibm_is_security_group:
+    state: "{{ item.state | default('available') }}"
+    id: "{{ security_group_existing.results[index].resource.id | default(omit) }}"
+    name: "{{ item.name }}"
+    vpc: "{{ vpc_config.resource.id }}"
+  loop: "{{ ibm_vpc_instance_security_groups }}"
+  loop_control:
+    index_var: index
+  register: security_group_config
+  when: ibm_vpc_instance_security_groups is defined
+
+- name: Refresh VPC config with security groups
+  ibm.cloudcollection.ibm_is_vpc_info:
+    name: "{{ vpc_config.resource.name }}"
+  register: vpc_config
+
+- name: Build security group name to ID map
+  set_fact:
+    security_group_map: "{{ (security_group_map | default({})) | combine({item.group_name: item.group_id}) }}"
+  loop: "{{ vpc_config.resource.security_group }}"
+
+- name: Configure security group rules
+  ibm.cloudcollection.ibm_is_security_group_rule:
+    state: "{{ item.state | default('available') }}"
+    icmp: "{{ item.icmp | default(omit) }}"
+    tcp: "{{ item.tcp | default(omit) }}"
+    group: "{{ security_group_map[(item.name|default(None))] | default(vpc_config.resource.default_security_group) }}"
+    direction: "{{ item.direction | default(omit) }}"
+    ip_version: "{{ item.ip_version | default(omit) }}"
+    remote: "{{ item.remote | default(omit) }}"
+    udp: "{{ item.udp | default(omit) }}"
+  loop: "{{ ibm_vpc_instance_security_group_rules }}"
+  when:
+    - ibm_vpc_instance_security_group_rules is defined
+    - ibm_vpc_instance_security_group_rules != None
+
 - name: Check for existing subnets
   ibm.cloudcollection.ibm_is_subnet_info:
     name: "{{ item.name }}"
@@ -93,11 +139,6 @@
       subnet: "{{ subnet_map[item.subnet] | default(item.subnet) }}"
   loop: "{{ ibm_vpc_instance_network_interfaces }}"
   when: ibm_vpc_instance_network_interfaces is defined
-
-- name: Build security group name to ID map
-  set_fact:
-    security_group_map: "{{ (security_group_map | default({})) | combine({item.group_name: item.group_id}) }}"
-  loop: "{{ vpc_config.resource.security_group }}"
 
 - name: Translate primary network interface security group name to ID
   set_fact:
@@ -270,22 +311,6 @@
     - ibm_vpc_instance_floating_ip is defined
     - ibm_vpc_instance_floating_ip.name is defined
     - ibm_vpc_instance_floating_ip.name != None
-
-# TODO: Lookup security group ID by name
-- name: Configure security group rules
-  ibm.cloudcollection.ibm_is_security_group_rule:
-    state: "{{ item.state | default('available') }}"
-    icmp: "{{ item.icmp | default(omit) }}"
-    tcp: "{{ item.tcp | default(omit) }}"
-    group: "{{ item.group | default(vpc_config.resource.default_security_group) }}"
-    direction: "{{ item.direction | default(omit) }}"
-    ip_version: "{{ item.ip_version | default(omit) }}"
-    remote: "{{ item.remote | default(omit) }}"
-    udp: "{{ item.udp | default(omit) }}"
-  loop: "{{ ibm_vpc_instance_security_group_rules }}"
-  when:
-    - ibm_vpc_instance_security_group_rules is defined
-    - ibm_vpc_instance_security_group_rules != None
 
 - name: Set 'ibm_vpc_instance_config' fact for use outside role
   set_fact:

--- a/roles/ibm_vpc_instance/tasks/main.yml
+++ b/roles/ibm_vpc_instance/tasks/main.yml
@@ -1,0 +1,288 @@
+---
+- name: Retrieve image list
+  ibm.cloudcollection.ibm_is_images_info:
+  register: images_list
+
+- name: Build VM image name to ID map
+  set_fact:
+    cacheable: True
+    image_map: "{{ images_list.resource.images |
+                   items2dict(key_name='name', value_name='id') }}"
+
+- name: Lookup image ID
+  set_fact:
+    image_id: "{{ image_map[ibm_vpc_instance_image] }}"
+  when: ibm_vpc_instance_image is defined
+
+# TODO: [WARNING]: Module did not set no_log for passphrase
+# Need to investigate and submit PR to upstream TF provider
+- name: Check for existing virtual server instance
+  ibm.cloudcollection.ibm_is_instance_info:
+    name: "{{ ibm_vpc_instance_name }}"
+  failed_when:
+    - instance_existing.rc != 0
+    - '"No Instance found" not in instance_existing.stderr'
+  register: instance_existing
+
+- name: Check for existing VPC
+  ibm.cloudcollection.ibm_is_vpc_info:
+    name: "{{ ibm_vpc_instance_vpc }}"
+  failed_when:
+    - vpc_existing.rc != 0
+    - '"No VPC found" not in vpc_existing.stderr'
+  register: vpc_existing
+  when: ibm_vpc_instance_vpc is defined
+
+- name: Configure VPC
+  ibm.cloudcollection.ibm_is_vpc:
+    state: available
+    id: "{{ vpc_existing.resource.id | default(instance_existing.resource.vpc) | default(omit) }}"
+    name: "{{ ibm_vpc_instance_vpc | default(omit) }}"
+  register: vpc_config
+
+- name: Check for existing subnets
+  ibm.cloudcollection.ibm_is_subnet_info:
+    name: "{{ item.name }}"
+  loop: "{{ ibm_vpc_instance_subnets }}"
+  failed_when:
+    - subnet_existing.rc != 0
+    - False  # TODO: Terraform crash (bug) when subnet does not exist
+  register: subnet_existing
+  when: ibm_vpc_instance_subnets is defined
+
+- name: Configure subnets
+  ibm.cloudcollection.ibm_is_subnet:
+    state: available
+    id: "{{ subnet_existing.results[index].resource.id | default(omit) }}"
+    name: "{{ item.name }}"
+    vpc: "{{ vpc_config.resource.id }}"
+    ipv4_cidr_block: "{{ item.ipv4_cidr_block | default(omit) }}"
+    zone: "{{ ibm_vpc_instance_zone | default(instance_existing.resource.zone) }}"
+    network_acl: "{{ item.network_acl | default(omit) }}"
+    public_gateway: "{{ item.public_gateway | default(omit) }}"
+    total_ipv4_address_count: "{{ item.total_ipv4_address_count | default(omit) }}"
+  loop: "{{ ibm_vpc_instance_subnets }}"
+  loop_control:
+    index_var: index
+  register: subnet_config
+  when: ibm_vpc_instance_subnets is defined
+
+- name: Retrieve list of all subnets
+  ibm.cloudcollection.ibm_is_subnets_info:
+  register: subnets_all
+
+- name: Build subnet name to ID map
+  set_fact:
+    subnet_map: "{{ (subnet_map | default({})) | combine({item.name: item.id}) }}"
+  loop: "{{ subnets_all.resource.subnets }}"
+
+- name: Translate primary network interface subnet name to ID
+  set_fact:
+    primary_network_interface: "{{ (primary_network_interface | default([])) + [item | combine(name_to_id)]}}"
+  vars:
+    name_to_id:
+      subnet: "{{ subnet_map[item.subnet] | default(item.subnet) }}"
+  loop: "{{ ibm_vpc_instance_primary_network_interface }}"
+  when: ibm_vpc_instance_primary_network_interface is defined
+
+- name: Translate network interface(s) subnet name to ID
+  set_fact:
+    network_interfaces: "{{ (network_interfaces | default([])) + [item | combine(name_to_id)]}}"
+  vars:
+    name_to_id:
+      subnet: "{{ subnet_map[item.subnet] | default(item.subnet) }}"
+  loop: "{{ ibm_vpc_instance_network_interfaces }}"
+  when: ibm_vpc_instance_network_interfaces is defined
+
+- name: Build security group name to ID map
+  set_fact:
+    security_group_map: "{{ (security_group_map | default({})) | combine({item.group_name: item.group_id}) }}"
+  loop: "{{ vpc_config.resource.security_group }}"
+
+- name: Translate primary network interface security group name to ID
+  set_fact:
+    primary_network_interface_sgs: "{{ (primary_network_interface_sgs | default([])) + [name_to_id] }}"
+  loop: "{{ primary_network_interface.security_groups }}"
+  vars:
+    name_to_id: "{{ security_group_map[item] | default(item) }}"
+  when:
+    - primary_network_interface.security_groups is defined
+
+- name: Build primary network interface with security group IDs
+  set_fact:
+    primary_network_interface_with_ids: "{{ [primary_network_interface | combine({'security_groups': (primary_network_interface_sgs | default([vpc_config.resource.default_security_group]))})] }}"
+
+- name: Translate network interface(s) security group name(s) to ID
+  include_tasks: network_interfaces_sgs.yml
+  loop: "{{ network_interfaces }}"
+  loop_control:
+    index_var: interface_index
+    loop_var: interface
+  when: network_interfaces is defined
+
+- name: Build network interfaces list with security group IDs
+  set_fact:
+    network_interfaces_with_ids: "{{ (network_interfaces_with_ids | default([])) + [item | combine({'security_groups': (network_interfaces_sgs[interface_index] | default(vpc_config.resource.default_security_group))})] }}"
+  loop: "{{ network_interfaces }}"
+  loop_control:
+    index_var: interface_index
+  when: network_interfaces_sgs is defined
+
+- name: Check for existing keys
+  ibm.cloudcollection.ibm_is_ssh_key_info:
+    name: "{{ item.name }}"
+  loop: "{{ ibm_vpc_instance_keys }}"
+  failed_when:
+    - ssh_key_existing.rc != 0
+    - '"No SSH Key found" not in ssh_key_existing.stderr'
+  register: ssh_key_existing
+  when: ibm_vpc_instance_keys is defined
+
+- name: Configure keys
+  ibm.cloudcollection.ibm_is_ssh_key:
+    state: available
+    id: "{{ ssh_key_existing.results[index].resource.id | default(omit) }}"
+    name: "{{ item.name }}"
+    public_key: "{{ item.public_key | default(omit) }}"
+    tags: "{{ item.tags | default(omit) }}"
+  loop: "{{ ibm_vpc_instance_keys }}"
+  loop_control:
+    index_var: index
+  register: ssh_key_config
+  when: ibm_vpc_instance_keys is defined
+
+- name: Init list of key IDs
+  set_fact:
+    ssh_key_ids: []
+  when: ibm_vpc_instance_keys is defined
+
+- name: Build list of key IDs
+  set_fact:
+    ssh_key_ids: "{{ ssh_key_ids + [item.resource.id] }}"
+  loop: "{{ ssh_key_config.results }}"
+  when: ibm_vpc_instance_keys is defined
+
+- name: Check for existing block storage volumes
+  ibm.cloudcollection.ibm_is_volume_info:
+    name: "{{ item.name }}"
+  loop: "{{ ibm_vpc_instance_volumes }}"
+  failed_when:
+    - volume_existing.rc != 0
+    - '"No Volume found" not in volume_existing.stderr'
+  register: volume_existing
+  when: ibm_vpc_instance_volumes is defined
+
+- name: Configure block storage volumes
+  ibm.cloudcollection.ibm_is_volume:
+    state: available
+    id: "{{ volume_existing.results[index].resource.id | default(omit) }}"
+    name: "{{ item.name }}"
+    capacity: "{{ item.capacity | default(omit) }}"
+    iops: "{{ item.iops | default(omit) }}"
+    profile: "{{ item.profile | default(omit) }}"
+    tags: "{{ item.tags | default(omit) }}"
+    zone: "{{ ibm_vpc_instance_zone | default(instance_existing.resource.zone) }}"
+  loop: "{{ ibm_vpc_instance_volumes }}"
+  loop_control:
+    index_var: index
+  register: volume_config
+  when: ibm_vpc_instance_volumes is defined
+
+- name: Build volume name to ID map
+  set_fact:
+    volume_map: "{{ volume_map | default({}) | combine({item.resource.name: item.resource.id}) }}"
+  loop: "{{ volume_config.results }}"
+  when: ibm_vpc_instance_volumes is defined
+
+- name: Extract list of volume IDs
+  set_fact:
+    volume_ids: "{{ volume_map.values() | list }}"
+  when:
+    - ibm_vpc_instance_volumes is defined
+    - volume_map is defined
+
+- name: Set empty volume ID list
+  set_fact:
+    volume_ids: []
+  when:
+    - ibm_vpc_instance_volumes is defined
+    - volume_map is not defined
+
+# TODO: Bugin Ansible 'ibm_is_instance' module - >1 network interfaces not formatted correctly:
+# resource ibm_is_instance "instance1" {
+#   ...
+#   network_interfaces {
+#     subnet = "<subnet1_id>"
+#     name = "eth1"
+#     }
+#     subnet = "<subnet2_id>"
+#     name = "eth2"
+#     }
+# }
+- name: Configure virtual server instance
+  ibm.cloudcollection.ibm_is_instance:
+    state: available
+    id: "{{ instance_existing.resource.id | default(omit) }}"
+    name: "{{ ibm_vpc_instance_name }}"
+    vpc: "{{ vpc_config.resource.id }}"
+    profile: "{{ ibm_vpc_instance_profile | default(instance_existing.resource.profile) }}"
+    image: "{{ image_id | default(instance_existing.resource.image) }}"
+    keys: "{{ ssh_key_ids | default(instance_existing.resource.keys) | default([]) }}"
+    primary_network_interface: "{{ primary_network_interface_with_ids | default(instance_existing.resource.primary_network_interface) }}"
+    network_interfaces: "{{ network_interfaces_with_ids | default(instance_existing.resource.network_interface) | default(omit) }}"
+    zone: "{{ ibm_vpc_instance_zone | default(instance_existing.resource.zone) }}"
+    force_recovery_time: "{{ ibm_vpc_instance_force_recovery_time | default(omit) }}"
+    tags: "{{ ibm_vpc_instance_tags | default(omit) }}"
+    volumes: "{{ volume_ids | default(instance_existing.resource.volumes) | default(omit) }}"
+  register: instance_config
+
+- name: Check for existing floating IP address
+  ibm.cloudcollection.ibm_is_floating_ip_info:
+    name: "{{ ibm_vpc_instance_floating_ip.name }}"
+  failed_when:
+    - floating_ip_existing.rc != 0
+    - '"No floatingIP found" not in floating_ip_existing.stderr'
+  register: floating_ip_existing
+  when:
+    - ibm_vpc_instance_floating_ip is defined
+    - ibm_vpc_instance_floating_ip.name is defined
+    - ibm_vpc_instance_floating_ip.name != None
+
+# TODO: Lookup Floating IP target by interface name
+# "{{ instance_config.resource.network_interfaces + instance_config.resource.primary_network_interface }}
+- name: Configure floating IP address
+  ibm.cloudcollection.ibm_is_floating_ip:
+    state: "{{ ibm_vpc_instance_floating_ip.state | default('available') }}"
+    id: "{{ floating_ip_existing.resource.id | default(omit) }}"
+    name: "{{ ibm_vpc_instance_floating_ip.name }}"
+    target: "{{ ibm_vpc_instance_floating_ip.target | default(instance_config.resource.primary_network_interface[0]['id']) }}"
+    tags: "{{ ibm_vpc_instance_floating_ip.tags | default(omit) }}"
+  register: floating_ip_config
+  when:
+    - ibm_vpc_instance_floating_ip is defined
+    - ibm_vpc_instance_floating_ip.name is defined
+    - ibm_vpc_instance_floating_ip.name != None
+
+- name: Print floating IP address
+  debug:
+    msg: "Floating IP Address: {{ floating_ip_config.resource.address }}"
+  when:
+    - ibm_vpc_instance_floating_ip is defined
+    - ibm_vpc_instance_floating_ip.name is defined
+    - ibm_vpc_instance_floating_ip.name != None
+
+# TODO: Lookup security group ID by name
+- name: Configure security group rules
+  ibm.cloudcollection.ibm_is_security_group_rule:
+    state: "{{ item.state | default('available') }}"
+    icmp: "{{ item.icmp | default(omit) }}"
+    tcp: "{{ item.tcp | default(omit) }}"
+    group: "{{ item.group | default(vpc_config.resource.default_security_group) }}"
+    direction: "{{ item.direction | default(omit) }}"
+    ip_version: "{{ item.ip_version | default(omit) }}"
+    remote: "{{ item.remote | default(omit) }}"
+    udp: "{{ item.udp | default(omit) }}"
+  loop: "{{ ibm_vpc_instance_security_group_rules }}"
+  when:
+    - ibm_vpc_instance_security_group_rules is defined
+    - ibm_vpc_instance_security_group_rules != None

--- a/roles/ibm_vpc_instance/tasks/main.yml
+++ b/roles/ibm_vpc_instance/tasks/main.yml
@@ -286,3 +286,7 @@
   when:
     - ibm_vpc_instance_security_group_rules is defined
     - ibm_vpc_instance_security_group_rules != None
+
+- name: Set 'ibm_vpc_instance_config' fact for use outside role
+  set_fact:
+    ibm_vpc_instance_config: "{{ instance_config.resource | combine({'floating_ip': (floating_ip_config.resource | default(None))}) }}"

--- a/roles/ibm_vpc_instance/tasks/main.yml
+++ b/roles/ibm_vpc_instance/tasks/main.yml
@@ -233,6 +233,7 @@
     force_recovery_time: "{{ ibm_vpc_instance_force_recovery_time | default(omit) }}"
     tags: "{{ ibm_vpc_instance_tags | default(omit) }}"
     volumes: "{{ volume_ids | default(instance_existing.resource.volumes) | default(omit) }}"
+    user_data: "{{ ibm_vpc_instance_user_data | default(omit) }}"
   register: instance_config
 
 - name: Check for existing floating IP address

--- a/roles/ibm_vpc_instance/tasks/main.yml
+++ b/roles/ibm_vpc_instance/tasks/main.yml
@@ -86,6 +86,27 @@
     - ibm_vpc_instance_security_group_rules is defined
     - ibm_vpc_instance_security_group_rules != None
 
+- name: Check for existing public gateway
+  ibm.cloudcollection.ibm_is_public_gateway_info:
+    name: "{{ ibm_vpc_instance_public_gateway.name }}"
+  failed_when:
+    - public_gateway_existing.rc != 0
+    - '"No Public gateway found" not in public_gateway_existing.stderr'
+  register: public_gateway_existing
+  when: ibm_vpc_instance_public_gateway is defined
+
+- name: Configure public gateway
+  ibm.cloudcollection.ibm_is_public_gateway:
+    state: available
+    id: "{{ public_gateway_existing.resource.id | default(omit) }}"
+    name: "{{ ibm_vpc_instance_public_gateway.name }}"
+    floating_ip: "{{ ibm_vpc_instance_public_gateway.floating_ip | default(omit) }}"
+    tags: "{{ ibm_vpc_instance_public_gateway.tags | default(omit) }}"
+    vpc: "{{ vpc_config.resource.id }}"
+    zone: "{{ ibm_vpc_instance_zone | default(instance_existing.resource.zone) }}"
+  register: public_gateway_config
+  when: ibm_vpc_instance_public_gateway is defined
+
 - name: Check for existing subnets
   ibm.cloudcollection.ibm_is_subnet_info:
     name: "{{ item.name }}"
@@ -105,7 +126,7 @@
     ipv4_cidr_block: "{{ item.ipv4_cidr_block | default(omit) }}"
     zone: "{{ ibm_vpc_instance_zone | default(instance_existing.resource.zone) }}"
     network_acl: "{{ item.network_acl | default(omit) }}"
-    public_gateway: "{{ item.public_gateway | default(omit) }}"
+    public_gateway: "{{ public_gateway_config.resource.id | default(omit) }}"
     total_ipv4_address_count: "{{ item.total_ipv4_address_count | default(omit) }}"
   loop: "{{ ibm_vpc_instance_subnets }}"
   loop_control:
@@ -314,4 +335,4 @@
 
 - name: Set 'ibm_vpc_instance_config' fact for use outside role
   set_fact:
-    ibm_vpc_instance_config: "{{ instance_config.resource | combine({'floating_ip': (floating_ip_config.resource | default(None))}) }}"
+    ibm_vpc_instance_config: "{{ instance_config.resource | combine({'floating_ip': (floating_ip_config.resource | default(None))}) | combine({'public_gateway': (public_gateway_config.resource | default(None))}) }}"

--- a/roles/ibm_vpc_instance/tasks/network_interfaces_sgs.yml
+++ b/roles/ibm_vpc_instance/tasks/network_interfaces_sgs.yml
@@ -1,0 +1,8 @@
+---
+- name: Translate network interface(s) security group name(s) to ID
+  set_fact:
+    network_interfaces_sgs: "{{ (network_interfaces_sgs | default({})) | combine({interface_index: ((network_interfaces_sgs[interface_index]|default([])) + [name_to_id])}) }}"
+  loop: "{{ interface.security_groups }}"
+  vars:
+    name_to_id: "{{ security_group_map[item] | default(item) }}"
+  when: interface.security_groups is defined

--- a/roles/ibm_vpc_instance/tests/inventory
+++ b/roles/ibm_vpc_instance/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/ibm_vpc_instance/tests/test.yml
+++ b/roles/ibm_vpc_instance/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ibm_vpc_instance

--- a/roles/ibm_vpc_instance/vars/main.yml
+++ b/roles/ibm_vpc_instance/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for ibm_vpc_instance


### PR DESCRIPTION
@danmk3 and I are working to create an idempotent VPC virtual server instance role that allows resource creation/assignment via human readable names.

## TODOs: features
- [ ] Update role README
- [x] Implement variable to pass `user_data` to `ibm_is_instance` (5a01007)
- [x] Implement creation of new security groups (8364e66)
- [x] Lookup security group ID by name (when adding SG rules) (277a95e)
- [x] Add public gateway attach/configure (fb99542)

### TODOs: bug fixes
- [ ] Security groups rules are always added (should be idempotent).
- [ ] If instance already exists it is destroyed and re-created (should be idempotent).

### TODOs: `ibm.cloudcollection` bug fixes
- [x] The `ibm_is_instance_info` module throws a `[WARNING]: Module did not set no_log for passphrase`. (https://github.com/IBM-Cloud/terraform-provider-ibm/pull/2057)
- [x] The `ibm_is_subnet_info` module crashes Terraform when subnet does not exist. (https://github.com/IBM-Cloud/terraform-provider-ibm/issues/2058)
- [ ] The `ibm_is_instance` module does not properly format multiple `network_interfaces` items.

## Testing
### Ansible 2.9
```
git clone https://github.com/jaywcarman/ansible-collection-ibm
cd ansible-collection-ibm
ansible-galaxy collection build
ansible-galaxy collection install <full_path_from_last_cmd_output>/ansible-collection-ibm/ibm-cloudcollection-1.10.0.tar.gz --force
```
### Ansible 2.10
```
ansible-galaxy collection install git+https://github.com/jaywcarman/ansible-collection-ibm.git,role/ibm_vpc_instance --force
```