### PR TITLE
VPC region/zone update in destroy.yaml

### DIFF
--- a/examples/simple-vm-ssh/create.yml
+++ b/examples/simple-vm-ssh/create.yml
@@ -7,7 +7,7 @@
     - name: Fetch the variables from var file
       include_vars:
         file: vars.yml
-  
+
     - name: Configure VPC
       ibm_is_vpc:
         name: "{{ name_prefix }}-vpc"

--- a/examples/simple-vm-ssh/destroy.yml
+++ b/examples/simple-vm-ssh/destroy.yml
@@ -10,19 +10,20 @@
     - name: Release Floating IP
       ibm_is_floating_ip:
         state: absent
-        id: "{{ fip.id }}"
+        id: "{{ fip }}"
       when: fip is defined
 
     - name: Remove VSI
       ibm_is_instance:
         state: absent
-        id: "{{ vsi.id }}"
+        id: "{{ vsi }}"
         keys: []
       when: vsi is defined
 
     - name: Get the ssh Key
       ibm_is_ssh_key_info:
         name: "{{ name_prefix }}-ssh-key"
+        region: "{{ zone }}"
       register: ssh_key_output
 
     - name: set ssh key in fact
@@ -39,12 +40,13 @@
     - name: Remove VPC Subnet
       ibm_is_subnet:
         state: absent
-        id: "{{ subnet.id }}"
+        id: "{{ subnet }}"
       when: subnet is defined
 
     - name: Get the vpc details
       ibm_is_vpc_info:
         name: "{{ name_prefix }}-vpc"
+        region: "{{ zone }}"
       register: vpc_output
 
     - name: set subnet in fact


### PR DESCRIPTION
**Issue:**

In VPC Virtual Server Instance destroy ansible playbook, all get info takes default zone `us-south`.  So, if we have a resource in different zone/region, Destroy ansible playbook is getting failed.

**Fix:**

1. Updated the zone/region in all the places where it is required.
2. According to the example destroy command in the README.md, modified the variable name.