### PR TITLE
Fix ID attribute used to import 'ibm_pi' resources

### DIFF
--- a/plugins/module_utils/ibmcloud.py
+++ b/plugins/module_utils/ibmcloud.py
@@ -585,6 +585,9 @@ class Resource:
         self.id_ = None
         if 'id' in parameters:
             self.id_ = parameters['id']
+            if (self.resource_type.startswith('ibm_pi') and
+                    'pi_cloud_instance_id' in parameters):
+                self.id_ = parameters['pi_cloud_instance_id'] + '/' + self.id_
 
 
 class Terraform:

--- a/plugins/module_utils/ibmcloud.py
+++ b/plugins/module_utils/ibmcloud.py
@@ -871,6 +871,8 @@ class Terraform:
                             _dict['name'] = arg['name']
                         if 'subnet' in arg:
                             _dict['subnet'] = arg['subnet']
+                        if 'network_id' in arg:
+                            _dict['network_id'] = arg['network_id']
                         safe_list.append(_dict)
                     else:
                         safe_list.append(arg)


### PR DESCRIPTION
The ID used to import 'ibm_pi' resources is a combination of the
'power_instance_id' and 'id' values.

fixes #46 