### PR TITLE
Fix IBM Cloud Terraform provider download URL

### DIFF
--- a/plugins/module_utils/ibmcloud.py
+++ b/plugins/module_utils/ibmcloud.py
@@ -728,7 +728,7 @@ class Terraform:
     def _install_ibmcloud_tf_provider(self):
         filename = 'terraform-provider-ibm_v' + self.ibm_provider_version
         self._download_extract_zip(
-            "{0}v{1}/{2}_amd64.zip".format(
+            "{0}v{1}/terraform-provider-ibm_{1}_{2}_amd64.zip".format(
                 self.IBM_PROVIDER_BASE_URL, self.ibm_provider_version, self.platform))
         os.chmod(os.path.join(self.terraform_dir, filename), 0o755)
 


### PR DESCRIPTION
Starting with v1.23.2 the IBM Cloud Terraform provider stopped releasing
the "{platform}_amd64.zip" archive as an asset. Only the more verbosely
named "terraform-provider-ibm_{version}_{platform}_amd64.zip" archives
are included.

https://github.com/IBM-Cloud/terraform-provider-ibm/releases

The download URL needs to be updated to use the longer archive names.

fixes #56 