### PR TITLE
Fix Terraform formatting of 'map' type arguments

### DIFF
--- a/plugins/module_utils/ibmcloud.py
+++ b/plugins/module_utils/ibmcloud.py
@@ -1082,9 +1082,9 @@ def fmt_tf_block(
         if key.endswith("_"):
             key = key[:-1]
         if isinstance(value, dict):
-            output += indent() + key + ' {\n'
+            output += indent() + key + ' = {\n'
             output += fmt_tf_block(value, indent_count + 1, indent_spaces)
-            output += indent(-1) + '}\n'
+            output += indent() + '}\n'
         elif isinstance(value, list):
             if len(value) >= 1 and isinstance(value[0], dict):
                 for item in value:


### PR DESCRIPTION
Terraform arguments need to be defined using an '='.

Currently the Terraform provider 'map' type arguments (translated to
'dict' in Python) are formatted omitting the '=' resulting in Terraform
interpreting it as a block, and raising an 'Error: Unsupported block
type' exception.

There's also an indentation mistake for the 'dict' type arguments which
didn't cause any errors but looked messy.