### PR TITLE
[WIP] Remove option to allow any top level parameter

### DIFF
--- a/plugins/module_utils/ibmcloud.py
+++ b/plugins/module_utils/ibmcloud.py
@@ -1065,8 +1065,7 @@ def fmt_tf_block(
         indent_space (int, optional): Number of spaces per indentation
         filter_None (bool, optional): Do not print any 'None' values
         validate_tl_params (list, optional): Only allow top level
-            parameters found on this list. If list is empty any top
-            level parameter is allowed.
+            parameters found on this list.
 
     Returns:
         str: Terraform block format
@@ -1077,7 +1076,7 @@ def fmt_tf_block(
         return ' ' * ((indent_count + extra_count) * indent_spaces)
 
     for key, value in arg_dict.items():
-        if len(validate_tl_params) > 0 and key not in validate_tl_params:
+        if key not in validate_tl_params:
             continue
         if key.endswith("_"):
             key = key[:-1]


### PR DESCRIPTION
Some modules do not support _any_ top level parameters, which is also
represented as an empty list (causing unsupported arguments like
'ibmcloud_api_key' to be templated into the Terraform block). There
aren't any modules that allow arbitrary parameters so this option is not
even needed.

fixes #61 