### PR TITLE
Fix documentation of 'region' parameter

### DIFF
--- a/examples/simple-vm-power-vs/README.md
+++ b/examples/simple-vm-power-vs/README.md
@@ -50,7 +50,7 @@ The following parameters can be set by the user:
     export IC_REGION=<REGION_NAME_HERE>
     ```
 
-    Note: Modules also support the 'ibmcloud_region' parameter.
+    Note: Modules also support the 'region' parameter.
 
 4. Export desired IBM Cloud zone to the 'IC_ZONE' environment variable:
 

--- a/examples/simple-vm-ssh/README.md
+++ b/examples/simple-vm-ssh/README.md
@@ -48,7 +48,7 @@ The following parameters can be set by the user:
     export IC_REGION=<REGION_NAME_HERE>
     ```
 
-    Note: Modules also support the 'ibmcloud_region' parameter.
+    Note: Modules also support the 'region' parameter.
 
 ### Create
 


### PR DESCRIPTION
The 'ibmcloud_region' parameter was re-named to 'region' in 68c13f7, but
the example documentation was never updated.