### PR TITLE
Fix links to IBM Cloud API key documentation

### DIFF
--- a/examples/appid-instance-creation/README.md
+++ b/examples/appid-instance-creation/README.md
@@ -43,4 +43,4 @@ The following parameters can be set by the user:
     ```
     ansible-playbook destroy.yml
     ```
-[Obtain an IBM Cloud API key]:https://cloud.ibm.com/docs/iam?topic=iam-userapikey
+[Obtain an IBM Cloud API key]:https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui

--- a/examples/iam-user-invite/README.md
+++ b/examples/iam-user-invite/README.md
@@ -45,4 +45,4 @@ The following parameters can be set by the user:
     ```
     ansible-playbook destroy.yml
     ```
-[Obtain an IBM Cloud API key]:https://cloud.ibm.com/docs/iam?topic=iam-userapikey
+[Obtain an IBM Cloud API key]:https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui

--- a/examples/ibm-api-gateway/README.md
+++ b/examples/ibm-api-gateway/README.md
@@ -49,4 +49,4 @@ The following parameters can be set by the user:
     ```
     ansible-playbook destroy.yml
     ```
-[Obtain an IBM Cloud API key]:https://cloud.ibm.com/docs/iam?topic=iam-userapikey
+[Obtain an IBM Cloud API key]:https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui

--- a/examples/ibm-certificate-manager/README.md
+++ b/examples/ibm-certificate-manager/README.md
@@ -60,4 +60,4 @@ The following parameters can be set by the user:
     ```
     ansible-playbook destroy.yml
     ```
-[Obtain an IBM Cloud API key]:https://cloud.ibm.com/docs/iam?topic=iam-userapikey
+[Obtain an IBM Cloud API key]:https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui

--- a/examples/ibm-iks-classic-ROKS/README.md
+++ b/examples/ibm-iks-classic-ROKS/README.md
@@ -50,4 +50,4 @@ The following parameters can be set by the user:
     ```
     ansible-playbook destroy.yml
     ```
-[Obtain an IBM Cloud API key]:https://cloud.ibm.com/docs/iam?topic=iam-userapikey
+[Obtain an IBM Cloud API key]:https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui

--- a/examples/ibm-resource-group/README.md
+++ b/examples/ibm-resource-group/README.md
@@ -43,4 +43,4 @@ The following parameters can be set by the user:
     ```
     ansible-playbook destroy.yml
     ```
-[Obtain an IBM Cloud API key]:https://cloud.ibm.com/docs/iam?topic=iam-userapikey
+[Obtain an IBM Cloud API key]:https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui

--- a/examples/simple-vm-ssh/README.md
+++ b/examples/simple-vm-ssh/README.md
@@ -78,5 +78,5 @@ The following parameters can be set by the user:
 [retrieve available images]: #list-available-vsi-images-and-profiles
 [retrieve available profiles]: #list-available-vsi-images-and-profiles
 [Ansible search path]:https://docs.ansible.com/ansible/latest/dev_guide/overview_architecture.html#ansible-search-path
-[Obtain an IBM Cloud API key]:https://cloud.ibm.com/docs/iam?topic=iam-userapikey
+[Obtain an IBM Cloud API key]:https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui
 [Ansible search path]: https://docs.ansible.com/ansible/latest/dev_guide/overview_architecture.html#ansible-search-path


### PR DESCRIPTION
Fix example READMEs link to [Obtain an IBM Cloud API key](https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui).