### PR TITLE
fixed data sources without parameter issue

### DIFF
--- a/plugins/module_utils/ibmcloud.py
+++ b/plugins/module_utils/ibmcloud.py
@@ -372,7 +372,7 @@ from ansible.module_utils.six import ensure_str
 from ansible.module_utils.six import string_types
 
 DEFAULT_TF_DIR = '/var/tmp/ansible/ibmcloud/'
-RM_OBJECT_SUBDIRS = True
+RM_OBJECT_SUBDIRS = False
 
 
 def ibmcloud_terraform(
@@ -926,11 +926,12 @@ class Terraform:
                 resource.tf_type,
                 resource.resource_type,
                 resource.tf_name) + '{\n' +
-            fmt_tf_block(
-                resource.parameters,
-                indent_count=1,
-                indent_spaces=2,
-                validate_tl_params=resource.tl_all_params) + '}\n')
+                fmt_tf_block(
+                    resource.parameters,
+                    indent_count=1,
+                    indent_spaces=2,
+                    validate_tl_params=resource.tl_all_params,
+                    required_params=resource.tl_required_params) + '}\n')
 
         # Write terraform resource block to file
         resource_file = '{}_{}.tf'.format(
@@ -1074,7 +1075,8 @@ def fmt_tf_block(
         indent_count=0,
         indent_spaces=2,
         filter_None=True,
-        validate_tl_params=[]):
+        required_params = [],
+        validate_tl_params=None):
     """
     Format a dictionary of configuration arguments into Terraform
     block syntax.
@@ -1096,6 +1098,8 @@ def fmt_tf_block(
     def indent(extra_count=0):
         return ' ' * ((indent_count + extra_count) * indent_spaces)
 
+    if validate_tl_params is not None and len(required_params) == 0:
+        return output
     for key, value in arg_dict.items():
         if len(validate_tl_params) > 0 and key not in validate_tl_params:
             continue

--- a/plugins/module_utils/ibmcloud.py
+++ b/plugins/module_utils/ibmcloud.py
@@ -372,7 +372,7 @@ from ansible.module_utils.six import ensure_str
 from ansible.module_utils.six import string_types
 
 DEFAULT_TF_DIR = '/var/tmp/ansible/ibmcloud/'
-RM_OBJECT_SUBDIRS = False
+RM_OBJECT_SUBDIRS = True
 
 
 def ibmcloud_terraform(


### PR DESCRIPTION
PR fixes the issue of unsupported attributes for datasources without parameters

for example:

`ibm_is_public_gateways_info.py ` this module generates a TF config of the format below

```
data ibm_is_public_gateways "ansible_20220307-225058" {
}
```

LOG:
```

TASK [Fetch Public Gateway Details] ************************************************************************************************************************************************
task path: /Users/anil/.ansible/collections/ansible_collections/ibm/cloudcollection/examples/appid-instance-creation/create.yml:7
ok: [localhost] => {"changed": false, "rc": 0, "resource": {"id": "2022-03-07 18:20:50.670458 +0000 UTC", "public_gateways": []}, "stderr": "", "stderr_lines": [], "stdout": "data.ibm_is_public_gateways.ansible_20220307-235043: Refreshing state...\n\nWarning: Argument is deprecated\n\nThe generation field is deprecated and will be removed after couple of\nreleases\n\n\nApply complete! Resources: 0 added, 0 changed, 0 destroyed.\n", "stdout_lines": ["data.ibm_is_public_gateways.ansible_20220307-235043: Refreshing state...", "", "Warning: Argument is deprecated", "", "The generation field is deprecated and will be removed after couple of", "releases", "", "", "Apply complete! Resources: 0 added, 0 changed, 0 destroyed."]}
META: ran handlers
META: ran handlers

PLAY RECAP *************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


```