### PR TITLE
Simple VM SSH (VPC) example update

### DIFF
--- a/examples/multiple-vm-ssh/README.md
+++ b/examples/multiple-vm-ssh/README.md
@@ -1,0 +1,91 @@
+# IBM Cloud Ansible: VPC - Multiple Virtual Server Instances
+
+This example creates multiple Virtual Server Instances (VSI) inside of a
+Virtual Private Cloud (VPC). All VSIs are created using a common VPC, image,
+profile, SSH key, and subnet. Each VSI is attached to it's own public IP
+address and configured to allow incoming SSH connections (authenticated using
+an SSH key pair).
+
+The number of VSIs created can be configured via the 'vsi_count', defined in
+vars.yml
+
+## VPC Resources
+
+The following VPC infrastructure resources will be created (Ansible modules in
+parentheses):
+
+* VPC (ibm_is_vpc)
+* Subnet (ibm_is_subnet)
+* VSIs (ibm_is_instance)
+* Floating IP Addresses (ibm_is_floating_ip)
+* Security Group Rule (ibm_is_security_group_rule)
+
+## Configuration Parameters
+
+The following parameters can be set by the user:
+
+* `vsi_count`: Number of VSIs (and associated floating IP addresses) to create
+* `name_prefix`: Prefix used to name created resources
+* `vsi_image`: VSI image name ([retrieve available images])
+* `vsi_profile`: VSI profile name ([retrieve available profiles])
+* `ssh_public_key`: SSH Public Key
+* `total_ipv4_address_count`: Number of IPv4 addresses in VPC Subnet
+* `zone`: IBM Cloud zone
+
+## Running
+
+### Set API Key and Region
+
+1. [Obtain an IBM Cloud API key].
+
+2. Export your API key to the `IC_API_KEY` environment variable:
+
+    ```
+    export IC_API_KEY=<YOUR_API_KEY_HERE>
+    ```
+
+    Note: Modules also support the 'ibmcloud_api_key' parameter, but it is
+    recommended to only use this when encrypting your API key value.
+
+3. Export desired IBM Cloud region to the 'IC_REGION' environment variable:
+
+    ```
+    export IC_REGION=<REGION_NAME_HERE>
+    ```
+
+    Note: Modules also support the 'region' parameter.
+
+### Create
+
+To create all resources and test public SSH connection to the VM:
+
+1. Update variables in 'vars.yml'
+2. Run the 'create' playbook:
+
+    ```
+    ansible-playbook create.yml
+    ```
+
+### Destroy
+
+1. To destroy all resources run the 'destroy' playbook (resource names are read
+   from 'vars.yml'):
+
+    ```
+    ansible-playbook destroy.yml
+    ```
+
+### List
+
+1. To list available VSI Images and Profiles run the
+   'list_vsi_images_and_profiles' playbook:
+
+    ```
+    ansible-playbook list_vsi_images_and_profiles.yml
+    ```
+
+[retrieve available images]: #list-available-vsi-images-and-profiles
+[retrieve available profiles]: #list-available-vsi-images-and-profiles
+[Ansible search path]:https://docs.ansible.com/ansible/latest/dev_guide/overview_architecture.html#ansible-search-path
+[Obtain an IBM Cloud API key]:https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui
+[Ansible search path]: https://docs.ansible.com/ansible/latest/dev_guide/overview_architecture.html#ansible-search-path

--- a/examples/multiple-vm-ssh/create.yml
+++ b/examples/multiple-vm-ssh/create.yml
@@ -130,7 +130,6 @@
       add_host:
         name: "{{ item.resource.address }}"
         ansible_user: root
-        ansible_ssh_private_key_file: ~/.ssh/id_rsa_tmp_ansible
         groups: new_vsi
         ansible_ssh_extra_args: -o StrictHostKeyChecking=no
       loop: "{{ fip_list.results }}"

--- a/examples/multiple-vm-ssh/create.yml
+++ b/examples/multiple-vm-ssh/create.yml
@@ -52,7 +52,7 @@
     - name: Configure SSH Key
       ibm_is_ssh_key:
         name: "{{ ssh_key_name }}"
-        public_key: "{{ (ssh_public_key|split)[:2]|join(' ') }}"
+        public_key: "{{ ssh_public_key.split()[:2]|join(' ') }}"
         id: "{{ ssh_key.resource.id | default(omit) }}"
       register: ssh_key
 

--- a/examples/multiple-vm-ssh/create.yml
+++ b/examples/multiple-vm-ssh/create.yml
@@ -1,0 +1,154 @@
+---
+- name: Create IBM Cloud VPC VSI
+  hosts: localhost
+  collections:
+   - ibm.cloudcollection
+  tasks:
+    - name: Fetch the variables from var file
+      include_vars:
+        file: vars.yml
+
+    - name: Checking for existing VPC
+      ibm_is_vpc_info:
+        name: "{{ vpc_name }}"
+      failed_when:
+        - vpc.rc != 0
+        - '"No VPC found" not in vpc.stderr'
+      register: vpc
+
+    - name: Configure VPC
+      ibm_is_vpc:
+        name: "{{ vpc_name }}"
+        state: available
+        id: "{{ vpc.resource.id | default(omit) }}"
+      register: vpc
+
+    - name: Checking for existing VPC Subnet
+      ibm_is_subnet_info:
+        name: "{{ subnet_name }}"
+      failed_when:
+        - subnet.rc != 0
+        - '"No subnet found" not in subnet.stderr'
+      register: subnet
+
+    - name: Configure VPC Subnet
+      ibm_is_subnet:
+        name: "{{ subnet_name }}"
+        state: available
+        id: "{{ subnet.id | default(omit) }}"
+        vpc: "{{ vpc.resource.id }}"
+        total_ipv4_address_count: "{{ total_ipv4_address_count }}"
+        zone: "{{ zone }}"
+      register: subnet
+
+    - name: Checking for existing SSH key
+      ibm_is_ssh_key_info:
+        name: "{{ ssh_key_name }}"
+      failed_when:
+        - ssh_key.rc != 0
+        - '"No SSH Key found" not in ssh_key.stderr'
+      register: ssh_key
+
+    - name: Configure SSH Key
+      ibm_is_ssh_key:
+        name: "{{ ssh_key_name }}"
+        public_key: "{{ (ssh_public_key|split)[:2]|join(' ') }}"
+        id: "{{ ssh_key.resource.id | default(omit) }}"
+      register: ssh_key
+
+    - name: Retrieve image list
+      ibm_is_images_info:
+      register: images_list
+
+    - name: Set VM image name/id dictionary fact
+      set_fact:
+        image_dict: "{{ images_list.resource.images |
+                        items2dict(key_name='name', value_name='id') }}"
+
+    - name: Check for existing VSIs
+      ibm_is_instance_info:
+        name: "{{ vsi_name }}-{{ ansible_loop.index}}"
+      failed_when:
+        - vsi_list.rc != 0
+        - '"No Instance found" not in vsi_list.stderr'
+      register: vsi_list
+      loop: "{{ range(vsi_count)|list }}"
+      loop_control:
+        extended: yes
+
+    - name: Configure VSIs
+      ibm_is_instance:
+        name: "{{ vsi_name }}-{{ ansible_loop.index}}"
+        state: available
+        id: "{{ item.resource.id | default(omit) }}"
+        vpc: "{{ vpc.resource.id }}"
+        profile: "{{ vsi_profile }}"
+        image: "{{ image_dict[vsi_image] }}"
+        keys:
+         - "{{ ssh_key.resource.id }}"
+        primary_network_interface:
+         - subnet: "{{ subnet.resource.id }}"
+        zone: "{{ zone }}"
+      register: vsi_list
+      loop: "{{ vsi_list.results }}"
+      loop_control:
+        extended: yes
+
+    - name: Check for existing Floating IP Addresses
+      ibm_is_floating_ip_info:
+        name: "{{ fip_name }}-{{ ansible_loop.index}}"
+      failed_when:
+        - fip_list.rc != 0
+        - '"No floatingIP found" not in fip_list.stderr'
+      register: fip_list
+      loop: "{{ range(vsi_count)|list }}"
+      loop_control:
+        extended: yes
+
+    - name: Configure Floating IP Addresses
+      ibm_is_floating_ip:
+        name: "{{ fip_name }}-{{ ansible_loop.index}}"
+        state: available
+        id: "{{ fip_list[ansible_loop.index0].resource.id | default(omit) }}"
+        target: "{{ item.resource.primary_network_interface[0]['id'] }}"
+      register: fip_list
+      loop: "{{ vsi_list.results }}"
+      loop_control:
+        extended: yes
+
+    - name: Configure Security Group Rule to open SSH on the VSI
+      ibm_is_security_group_rule:
+        state: available
+        group: "{{ vpc.resource.default_security_group }}"
+        direction: inbound
+        remote: 0.0.0.0/0
+        tcp:
+          - port_max: 22
+            port_min: 22
+
+    - name: Add VSI to Ansible inventory
+      add_host:
+        name: "{{ item.resource.address }}"
+        ansible_user: root
+        ansible_ssh_private_key_file: ~/.ssh/id_rsa_tmp_ansible
+        groups: new_vsi
+        ansible_ssh_extra_args: -o StrictHostKeyChecking=no
+      loop: "{{ fip_list.results }}"
+
+- name: Check Ansible connection to new DEMO VSI
+  hosts: new_vsi
+  gather_facts: False
+  tasks:
+    - name: Wait for VSI to become reachable over SSH
+      wait_for_connection:
+
+- name: Check Ansible connection to new DEMO VSI
+  hosts: new_vsi
+  tasks:
+    - name: Collect OS information
+      shell: hostname && cat /etc/os-release
+      register: os_info
+
+    - name: Print OS information
+      debug:
+        var: os_info.stdout_lines

--- a/examples/multiple-vm-ssh/destroy.yml
+++ b/examples/multiple-vm-ssh/destroy.yml
@@ -1,0 +1,94 @@
+---
+- name: Destroy IBM Cloud VPC VSI
+  hosts: localhost
+  collections:
+   - ibm.cloudcollection
+  tasks:
+    - name: Fetch the variables from var file
+      include_vars:
+        file: vars.yml
+
+    - name: Check for existing Floating IPs
+      ibm_is_floating_ip_info:
+        name: "{{ fip_name }}-{{ ansible_loop.index}}"
+      failed_when:
+        - fip_list.rc != 0
+        - '"No floatingIP found" not in fip_list.stderr'
+      register: fip_list
+      loop: "{{ range(vsi_count)|list }}"
+      loop_control:
+        extended: yes
+
+    - name: Release Floating IPs
+      ibm_is_floating_ip:
+        state: absent
+        id: "{{ item.resource.id }}"
+      when: item.resource.id is defined
+      loop: "{{ fip_list.results }}"
+
+    - name: Check for existing VSIs
+      ibm_is_instance_info:
+        name: "{{ vsi_name }}-{{ ansible_loop.index}}"
+      failed_when:
+        - vsi_list.rc != 0
+        - '"No Instance found" not in vsi_list.stderr'
+      register: vsi_list
+      loop: "{{ range(vsi_count)|list }}"
+      loop_control:
+        extended: yes
+
+    - name: Remove VSIs
+      ibm_is_instance:
+        state: absent
+        id: "{{ item.resource.id }}"
+        vpc: "{{ item.resource.vpc }}"
+        keys: []
+        image: "{{ item.resource.image }}"
+        profile: "{{ item.resource.profile }}"
+        zone: "{{ item.resource.zone }}"
+        primary_network_interface:
+          - subnet: "{{ item.resource.primary_network_interface[0].subnet }}"
+      when: item.resource.id is defined
+      loop: "{{ vsi_list.results }}"
+
+    - name: Checking for existing SSH key
+      ibm_is_ssh_key_info:
+        name: "{{ ssh_key_name }}"
+      failed_when:
+        - ssh_key.rc != 0
+        - '"No SSH Key found" not in ssh_key.stderr'
+      register: ssh_key
+
+    - name: Remove SSH Key
+      ibm_is_ssh_key:
+        state: absent
+        id: "{{ ssh_key.resource.id }}"
+      when: ssh_key.resource.id is defined
+
+    - name: Checking for existing VPC Subnet
+      ibm_is_subnet_info:
+        name: "{{ subnet_name }}"
+      failed_when:
+        - subnet.rc != 0
+        - '"No subnet found" not in subnet.stderr'
+      register: subnet
+
+    - name: Remove VPC Subnet
+      ibm_is_subnet:
+        state: absent
+        id: "{{ subnet.resource.id }}"
+      when: subnet.resource.id is defined
+
+    - name: Checking for existing VPC
+      ibm_is_vpc_info:
+        name: "{{ vpc_name }}"
+      failed_when:
+        - vpc.rc != 0
+        - '"No VPC found" not in vpc.stderr'
+      register: vpc
+
+    - name: Remove VPC
+      ibm_is_vpc:
+        state: absent
+        id: "{{ vpc.resource.id }}"
+      when: vpc.resource.id is defined

--- a/examples/multiple-vm-ssh/list_vsi_images_and_profiles.yml
+++ b/examples/multiple-vm-ssh/list_vsi_images_and_profiles.yml
@@ -1,0 +1,19 @@
+---
+- name: List VPC Images and Instance Profiles
+  hosts: localhost
+  collections:
+   - ibm.cloudcollection
+
+  tasks:
+    - ibm_is_images_info:
+      register: images_list
+
+    - debug:
+        var: images_list.resource.images |
+             items2dict(key_name='name', value_name='id')
+
+    - ibm_is_instance_profiles_info:
+      register: instance_profiles_list
+
+    - debug:
+        var: instance_profiles_list.resource.profiles | list

--- a/examples/multiple-vm-ssh/vars.yml
+++ b/examples/multiple-vm-ssh/vars.yml
@@ -1,0 +1,13 @@
+---
+vsi_count: 5
+name_prefix: ansible-test
+vsi_image: ibm-debian-11-2-minimal-amd64-1
+vsi_profile: bx2-2x8
+ssh_public_key: '<ssh_public_key>'
+total_ipv4_address_count: 256
+zone: us-south-3
+vpc_name: "{{ name_prefix }}-vpc"
+subnet_name: "{{ name_prefix }}-subnet"
+ssh_key_name: "{{ name_prefix }}-ssh-key"
+vsi_name: "{{ name_prefix }}-vsi"
+fip_name: "{{ name_prefix }}-fip"

--- a/examples/simple-vm-ssh/README.md
+++ b/examples/simple-vm-ssh/README.md
@@ -52,8 +52,10 @@ The following parameters can be set by the user:
 
 ### Create
 
-1. To create all resources and test public SSH connection to the VM, run the
-   'create' playbook:
+To create all resources and test public SSH connection to the VM:
+
+1. Update variables in 'vars.yml'
+2. Run the 'create' playbook:
 
     ```
     ansible-playbook create.yml
@@ -61,13 +63,14 @@ The following parameters can be set by the user:
 
 ### Destroy
 
-1. To destroy all resources run the 'destroy' playbook:
+1. To destroy all resources run the 'destroy' playbook (resource names are read
+   from 'vars.yml'):
 
     ```
-    ansible-playbook destroy.yml -e "fip=<floating_ip_address_id> vsi=<vm_instance_id> subnet=<subnet_id>"
+    ansible-playbook destroy.yml
     ```
 
-### List 
+### List
 
 1. To list available VSI Images and Profiles run the 'list_vsi_images_and_profiles' playbook:
 

--- a/examples/simple-vm-ssh/README.md
+++ b/examples/simple-vm-ssh/README.md
@@ -24,7 +24,7 @@ The following parameters can be set by the user:
 * `vsi_image`: VSI image name ([retrieve available images])
 * `vsi_profile`: VSI profile name ([retrieve available profiles])
 * `ssh_public_key`: SSH Public Key
-* `ipv4_cidr_block`: IPv4 CIDR Block for VPC Subnet
+* `total_ipv4_address_count`: Number of IPv4 addresses in VPC Subnet
 * `zone`: IBM Cloud zone
 
 ## Running

--- a/examples/simple-vm-ssh/create.yml
+++ b/examples/simple-vm-ssh/create.yml
@@ -10,7 +10,7 @@
 
     - name: Configure VPC
       ibm_is_vpc:
-        name: "{{ name_prefix }}-vpc"
+        name: "{{ vpc_name }}"
         state: available
         id: "{{ vpc.id | default(omit) }}"
       register: vpc_create_output
@@ -22,7 +22,7 @@
 
     - name: Configure VPC Subnet
       ibm_is_subnet:
-        name: "{{ name_prefix }}-subnet"
+        name: "{{ subnet_name }}"
         state: available
         id: "{{ subnet.id | default(omit) }}"
         vpc: "{{ vpc.id }}"
@@ -59,7 +59,7 @@
 
     - name: Configure VSI
       ibm_is_instance:
-        name: "{{ name_prefix }}-vsi"
+        name: "{{ vsi_name }}"
         state: available
         id: "{{ vsi.id | default(omit) }}"
         vpc: "{{ vpc.id }}"
@@ -79,7 +79,7 @@
 
     - name: Configure Floating IP Address
       ibm_is_floating_ip:
-        name: "{{ name_prefix }}-fip"
+        name: "{{ fip_name }}"
         state: available
         id: "{{ fip.id | default(omit) }}"
         target: "{{ vsi.primary_network_interface[0]['id'] }}"
@@ -92,7 +92,7 @@
 
     - name: Print Floating IP Address
       debug:
-        msg: "IP Address: {{ fip.address }}"
+        msg: "{{ vsi_name }} IP Address: {{ fip.resource.address }}"
 
     - name: Configure Security Group Rule to open SSH on the VSI
       ibm_is_security_group_rule:

--- a/examples/simple-vm-ssh/create.yml
+++ b/examples/simple-vm-ssh/create.yml
@@ -8,44 +8,53 @@
       include_vars:
         file: vars.yml
 
+    - name: Checking for existing VPC
+      ibm_is_vpc_info:
+        name: "{{ vpc_name }}"
+      failed_when:
+        - vpc.rc != 0
+        - '"No VPC found" not in vpc.stderr'
+      register: vpc
+
     - name: Configure VPC
       ibm_is_vpc:
         name: "{{ vpc_name }}"
         state: available
-        id: "{{ vpc.id | default(omit) }}"
-      register: vpc_create_output
+        id: "{{ vpc.resource.id | default(omit) }}"
+      register: vpc
 
-    - name: Save VPC as fact
-      set_fact:
-        cacheable: True
-        vpc: "{{ vpc_create_output.resource }}"
+    - name: Checking for existing VPC Subnet
+      ibm_is_subnet_info:
+        name: "{{ subnet_name }}"
+      failed_when:
+        - subnet.rc != 0
+        - '"No subnet found" not in subnet.stderr'
+      register: subnet
 
     - name: Configure VPC Subnet
       ibm_is_subnet:
         name: "{{ subnet_name }}"
         state: available
         id: "{{ subnet.id | default(omit) }}"
-        vpc: "{{ vpc.id }}"
+        vpc: "{{ vpc.resource.id }}"
         total_ipv4_address_count: "{{ total_ipv4_address_count }}"
         zone: "{{ zone }}"
-      register: subnet_create_output
+      register: subnet
 
-    - name: Save VPC Subnet as fact
-      set_fact:
-        cacheable: True
-        subnet: "{{ subnet_create_output.resource }}"
+    - name: Checking for existing SSH key
+      ibm_is_ssh_key_info:
+        name: "{{ ssh_key_name }}"
+      failed_when:
+        - ssh_key.rc != 0
+        - '"No SSH Key found" not in ssh_key.stderr'
+      register: ssh_key
 
     - name: Configure SSH Key
       ibm_is_ssh_key:
-        name: "{{ name_prefix }}-ssh-key"
-        public_key: "{{ ssh_public_key }}"
-        id: "{{ ssh_key.id | default(omit) }}"
-      register: ssh_key_create_output
-
-    - name: Save SSH Key as fact
-      set_fact:
-        cacheable: True
-        ssh_key: "{{ ssh_key_create_output.resource }}"
+        name: "{{ ssh_key_name }}"
+        public_key: "{{ (ssh_public_key|split)[:2]|join(' ') }}"
+        id: "{{ ssh_key.resource.id | default(omit) }}"
+      register: ssh_key
 
     - name: Retrieve image list
       ibm_is_images_info:
@@ -53,42 +62,47 @@
 
     - name: Set VM image name/id dictionary fact
       set_fact:
-        cacheable: True
         image_dict: "{{ images_list.resource.images |
                         items2dict(key_name='name', value_name='id') }}"
+
+    - name: Check for existing VSI
+      ibm_is_instance_info:
+        name: "{{ vsi_name }}"
+      failed_when:
+        - vsi.rc != 0
+        - '"No Instance found" not in vsi.stderr'
+      register: vsi
 
     - name: Configure VSI
       ibm_is_instance:
         name: "{{ vsi_name }}"
         state: available
-        id: "{{ vsi.id | default(omit) }}"
-        vpc: "{{ vpc.id }}"
+        id: "{{ vsi.resource.id | default(omit) }}"
+        vpc: "{{ vpc.resource.id }}"
         profile: "{{ vsi_profile }}"
         image: "{{ image_dict[vsi_image] }}"
         keys:
-          - "{{ ssh_key.id }}"
+         - "{{ ssh_key.resource.id }}"
         primary_network_interface:
-          - subnet: "{{ subnet.id }}"
+         - subnet: "{{ subnet.resource.id }}"
         zone: "{{ zone }}"
-      register: vsi_create_output
+      register: vsi
 
-    - name: Save VSI as fact
-      set_fact:
-        cacheable: True
-        vsi: "{{ vsi_create_output.resource }}"
+    - name: Check for existing Floating IP
+      ibm_is_floating_ip_info:
+        name: "{{ fip_name }}"
+      failed_when:
+        - fip.rc != 0
+        - '"No floatingIP found" not in fip.stderr'
+      register: fip
 
     - name: Configure Floating IP Address
       ibm_is_floating_ip:
         name: "{{ fip_name }}"
         state: available
-        id: "{{ fip.id | default(omit) }}"
-        target: "{{ vsi.primary_network_interface[0]['id'] }}"
-      register: fip_create_output
-
-    - name: Save Floating IP as fact
-      set_fact:
-        cacheable: True
-        fip: "{{ fip_create_output.resource }}"
+        id: "{{ fip.resource.id | default(omit) }}"
+        target: "{{ vsi.resource.primary_network_interface[0]['id'] }}"
+      register: fip
 
     - name: Print Floating IP Address
       debug:
@@ -97,7 +111,7 @@
     - name: Configure Security Group Rule to open SSH on the VSI
       ibm_is_security_group_rule:
         state: available
-        group: "{{ vpc.default_security_group }}"
+        group: "{{ vpc.resource.default_security_group }}"
         direction: inbound
         remote: 0.0.0.0/0
         tcp:
@@ -106,7 +120,7 @@
 
     - name: Add VSI to Ansible inventory
       add_host:
-        name: "{{ fip.address }}"
+        name: "{{ fip.resource.address }}"
         ansible_user: root
         groups: new_vsi
         ansible_ssh_extra_args: -o StrictHostKeyChecking=no

--- a/examples/simple-vm-ssh/create.yml
+++ b/examples/simple-vm-ssh/create.yml
@@ -7,7 +7,7 @@
     - name: Fetch the variables from var file
       include_vars:
         file: vars.yml
-  
+
     - name: Configure VPC
       ibm_is_vpc:
         name: "{{ name_prefix }}-vpc"

--- a/examples/simple-vm-ssh/create.yml
+++ b/examples/simple-vm-ssh/create.yml
@@ -52,7 +52,7 @@
     - name: Configure SSH Key
       ibm_is_ssh_key:
         name: "{{ ssh_key_name }}"
-        public_key: "{{ (ssh_public_key|split)[:2]|join(' ') }}"
+        public_key: "{{ ssh_public_key.split()[:2]|join(' ') }}"
         id: "{{ ssh_key.resource.id | default(omit) }}"
       register: ssh_key
 

--- a/examples/simple-vm-ssh/destroy.yml
+++ b/examples/simple-vm-ssh/destroy.yml
@@ -7,53 +7,80 @@
     - name: Fetch the variables from var file
       include_vars:
         file: vars.yml
+
+    - name: Check for existing Floating IP
+      ibm_is_floating_ip_info:
+        name: "{{ name_prefix }}-fip"
+      failed_when:
+        - fip.rc != 0
+        - '"No floatingIP found" not in fip.stderr'
+      register: fip
+
     - name: Release Floating IP
       ibm_is_floating_ip:
         state: absent
-        id: "{{ fip.id }}"
-      when: fip is defined
+        id: "{{ fip.resource.id }}"
+      when: fip.resource.id is defined
+
+    - name: Check for existing VSI
+      ibm_is_instance_info:
+        name: "{{ name_prefix }}-vsi"
+      failed_when:
+        - vsi.rc != 0
+        - '"No Instance found" not in vsi.stderr'
+      register: vsi
 
     - name: Remove VSI
       ibm_is_instance:
         state: absent
-        id: "{{ vsi.id }}"
+        id: "{{ vsi.resource.id }}"
+        vpc: "{{ vsi.resource.vpc }}"
         keys: []
-      when: vsi is defined
+        image: "{{ vsi.resource.image }}"
+        profile: "{{ vsi.resource.profile }}"
+        zone: "{{ vsi.resource.zone }}"
+        primary_network_interface:
+          - subnet: "{{ vsi.resource.primary_network_interface[0].subnet }}"
+      when: vsi.resource.id is defined
 
-    - name: Get the ssh Key
+    - name: Checking for existing SSH key
       ibm_is_ssh_key_info:
         name: "{{ name_prefix }}-ssh-key"
-      register: ssh_key_output
-
-    - name: set ssh key in fact
-      set_fact:
-        cacheable: True
-        ssh_key: "{{ ssh_key_output.resource }}"
+      failed_when:
+        - ssh_key.rc != 0
+        - '"No SSH Key found" not in ssh_key.stderr'
+      register: ssh_key
 
     - name: Remove SSH Key
       ibm_is_ssh_key:
         state: absent
-        id: "{{ ssh_key.id }}"
-      when: ssh_key is defined
+        id: "{{ ssh_key.resource.id }}"
+      when: ssh_key.resource.id is defined
+
+    - name: Checking for existing VPC Subnet
+      ibm_is_subnet_info:
+        name: "{{ name_prefix }}-subnet"
+      failed_when:
+        - subnet.rc != 0
+        - '"No subnet found" not in subnet.stderr'
+      register: subnet
 
     - name: Remove VPC Subnet
       ibm_is_subnet:
         state: absent
-        id: "{{ subnet.id }}"
-      when: subnet is defined
+        id: "{{ subnet.resource.id }}"
+      when: subnet.resource.id is defined
 
-    - name: Get the vpc details
+    - name: Checking for existing VPC
       ibm_is_vpc_info:
         name: "{{ name_prefix }}-vpc"
-      register: vpc_output
-
-    - name: set subnet in fact
-      set_fact:
-        cacheable: True
-        vpc: "{{ vpc_output.resource }}"
+      failed_when:
+        - vpc.rc != 0
+        - '"No VPC found" not in vpc.stderr'
+      register: vpc
 
     - name: Remove VPC
       ibm_is_vpc:
         state: absent
-        id: "{{ vpc.id }}"
-      when: vpc is defined
+        id: "{{ vpc.resource.id }}"
+      when: vpc.resource.id is defined

--- a/examples/simple-vm-ssh/destroy.yml
+++ b/examples/simple-vm-ssh/destroy.yml
@@ -10,7 +10,7 @@
 
     - name: Check for existing Floating IP
       ibm_is_floating_ip_info:
-        name: "{{ name_prefix }}-fip"
+        name: "{{ fip_name }}"
       failed_when:
         - fip.rc != 0
         - '"No floatingIP found" not in fip.stderr'
@@ -24,7 +24,7 @@
 
     - name: Check for existing VSI
       ibm_is_instance_info:
-        name: "{{ name_prefix }}-vsi"
+        name: "{{ vsi_name }}"
       failed_when:
         - vsi.rc != 0
         - '"No Instance found" not in vsi.stderr'
@@ -45,7 +45,7 @@
 
     - name: Checking for existing SSH key
       ibm_is_ssh_key_info:
-        name: "{{ name_prefix }}-ssh-key"
+        name: "{{ ssh_key_name }}"
       failed_when:
         - ssh_key.rc != 0
         - '"No SSH Key found" not in ssh_key.stderr'
@@ -59,7 +59,7 @@
 
     - name: Checking for existing VPC Subnet
       ibm_is_subnet_info:
-        name: "{{ name_prefix }}-subnet"
+        name: "{{ subnet_name }}"
       failed_when:
         - subnet.rc != 0
         - '"No subnet found" not in subnet.stderr'
@@ -73,7 +73,7 @@
 
     - name: Checking for existing VPC
       ibm_is_vpc_info:
-        name: "{{ name_prefix }}-vpc"
+        name: "{{ vpc_name }}"
       failed_when:
         - vpc.rc != 0
         - '"No VPC found" not in vpc.stderr'

--- a/examples/simple-vm-ssh/vars.yml
+++ b/examples/simple-vm-ssh/vars.yml
@@ -3,5 +3,10 @@ name_prefix: ansible-test
 vsi_image: ibm-debian-11-2-minimal-amd64-1
 vsi_profile: bx2-2x8
 ssh_public_key: '<ssh_public_key>'
+vpc_name: "{{ name_prefix }}-vpc"
+subnet_name: "{{ name_prefix }}-subnet"
 total_ipv4_address_count: 256
 zone: us-south-3
+ssh_key_name: "{{ name_prefix }}-ssh-key"
+vsi_name: "{{ name_prefix }}-vsi"
+fip_name: "{{ name_prefix }}-fip"

--- a/examples/simple-vm-ssh/vars.yml
+++ b/examples/simple-vm-ssh/vars.yml
@@ -1,6 +1,6 @@
 ---
 name_prefix: ansible-test
-vsi_image: ibm-ubuntu-16-04-05-64-minimal-for-vsi
+vsi_image: ibm-debian-11-2-minimal-amd64-1
 vsi_profile: bx2-2x8
 ssh_public_key: '<ssh_public_key>'
 total_ipv4_address_count: 256


### PR DESCRIPTION
The simple-vm-ssh example playbooks are due for some updates.

- [x] Update stale references (images, etc.)
- [x] Remove requirements to cache facts
- [x] Fix destroy.yml playbook
- [x] Add ability to create multiple VSI's from single playbook