### PR TITLE
Catch exception caused by concurrent terraform downloads

### DIFF
--- a/plugins/module_utils/ibmcloud.py
+++ b/plugins/module_utils/ibmcloud.py
@@ -730,7 +730,11 @@ class Terraform:
             os.makedirs(self.directory)
         resp = open_url(url)
         zip_archive = ZipFile(BytesIO(resp.read()))
-        zip_archive.extractall(path=self.terraform_dir)
+        try:
+            zip_archive.extractall(path=self.terraform_dir)
+        except OSError as err:
+            if err.errno != 26:  # [Errno 26] Text file busy usually caused by another thread downloading terraform
+                raise err
 
     def _install_terraform(self):
         filename = 'terraform'


### PR DESCRIPTION
If multiple playbooks are run concurrently, there is a chance more than
one thread will attempt to download the terraform executable. The first
thread to download will be fine, but any others will fail due to an
OSError 26 text file busy error. By catching the exception we can
attempt to continue _all_ threads, using the newly created terraform
executable.