### PR TITLE
fixing issues while checking powerVS network

### DIFF
--- a/examples/simple-vm-power-vs/create.yml
+++ b/examples/simple-vm-power-vs/create.yml
@@ -61,6 +61,7 @@
       failed_when:
         - pi_network_existing_output.rc != 0
         - '"unable to get network" not in pi_network_existing_output.stderr'
+        - '"Error:item not found" not in pi_network_existing_output.stderr'
       register: pi_network_existing_output
 
     - name: Save existing network as fact


### PR DESCRIPTION
To resolve issue mentioned here https://github.com/IBM-Cloud/ansible-collection-ibm/issues/113 
Error which we were getting is below ..

```
fatal: [localhost]: FAILED! => {"changed": false, "failed_when_result": true, "msg": "", "rc": 1, "resource": {"_name": "ansible_20230713-101802", "_type": "ibm_pi_network", "target": "ibm_pi_network.ansible_20230713-101802"}, "stderr": "\nError: failed to perform Get Network Operation for Network id ansible-demo-power-vm-network with error [GET /pcloud/v1/cloud-instances/{cloud_instance_id}/networks/{network_id}][404] pcloudNetworksGetNotFound  &{Code:0 Description:The network ID ansible-demo-power-vm-network could not be found on cloud instance 8235eb2d80ca4b96aaa6633a2eb771b6. Ensure the ID is correct and try again. If the error persists, contact support. Error:item not found Message:}\n\n  on ibm_pi_network_ansible_20230713-101802.tf line 1, in data \"ibm_pi_network\" \"ansible_20230713-101802\":\n   1: data ibm_pi_network \"ansible_20230713-101802\" {\n\n\n", "stderr_lines": ["", "Error: failed to perform Get Network Operation for Network id ansible-demo-power-vm-network with error [GET /pcloud/v1/cloud-instances/{cloud_instance_id}/networks/{network_id}][404] pcloudNetworksGetNotFound  &{Code:0 Description:The network ID ansible-demo-power-vm-network could not be found on cloud instance 8235eb2d80ca4b96aaa6633a2eb771b6. Ensure the ID is correct and try again. If the error persists, contact support. Error:item not found Message:}", "", "  on ibm_pi_network_ansible_20230713-101802.tf line 1, in data \"ibm_pi_network\" \"ansible_20230713-101802\":", "   1: data ibm_pi_network \"ansible_20230713-101802\" {", "", ""], "stdout": "data.ibm_pi_network.ansible_20230713-101802: Refreshing state...\n", "stdout_lines": ["data.ibm_pi_network.ansible_20230713-101802: Refreshing state..."]}

```
As error message has been changed in IBM cloud api calls , hence we had to add - "Error:item not found" message.