### PR TITLE
Remove duplicate region parameter from ibm_satellite_cluster_worker_pool_info

### DIFF
--- a/plugins/modules/ibm_satellite_cluster_worker_pool_info.py
+++ b/plugins/modules/ibm_satellite_cluster_worker_pool_info.py
@@ -36,11 +36,6 @@ options:
             - ID of the resource group
         required: False
         type: str
-    region:
-        description:
-            - Name of the region
-        required: False
-        type: str
     iaas_classic_username:
         description:
             - (Required when generation = 1) The IBM Cloud Classic
@@ -101,9 +96,6 @@ module_args = dict(
         required=True,
         type='str'),
     resource_group_id=dict(
-        required=False,
-        type='str'),
-    region=dict(
         required=False,
         type='str'),
     iaas_classic_username=dict(


### PR DESCRIPTION
Using `ibm_satellite_cluster_worker_pool_info` module causes the following error:

```File \"/var/folders/gz/y4bmq8nd7bq_qgl20zvn0j7m0000gp/T/ansible_ibm.cloudcollection.ibm_satellite_cluster_worker_pool_info_payload_v5e001vz/ansible_ibm.cloudcollection.ibm_satellite_cluster_worker_pool_info_payload.zip/ansible_collections/ibm/cloudcollection/plugins/modules/ibm_satellite_cluster_worker_pool_info.py\", line 119\nSyntaxError: keyword argument repeated: region\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}```

Due to duplicate `region` parameters. Removed the one not following the pattern of the other modules.